### PR TITLE
Replace multiple entries with single entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Maven build directory
+target/
+
 # Compiled class file
 *.class
 
@@ -21,16 +24,9 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# IDE specific config/settings files
 .vscode/
 .idea/
 *.iml
-target/maven-status/
-target/classes
-target/generated-sources
-target/generated-test-sources
-target/maven-archiver
-target/maven-status
-target/surefire-reports
-target/test-classes
 .classpath
 .settings/


### PR DESCRIPTION
Replace multiple `target/sub-directory` entries with **single entry**.

With reference to [hedera-keygen-java issue #7](https://github.com/hashgraph/hedera-keygen-java/issues/7), we **do not need** to track any specific files under `target/` directory.

The below binary files can be moved to [hedera-keygen-java tagged releases](https://github.com/hashgraph/hedera-keygen-java/releases), as mentioned in the above issue.

```
target/original-sdk-keygen-1.1.jar
target/sdk-keygen-1.1.jar
```