### PR TITLE
Remove redundant check

### DIFF
--- a/target/.gitignore
+++ b/target/.gitignore
@@ -1,2 +1,0 @@
-/classes/
-/test-classes/


### PR DESCRIPTION
With reference to another PR [ Replace multiple entries with single entry #8 ](https://github.com/hashgraph/hedera-keygen-java/pull/8), this `.gitignore` check is redundant.